### PR TITLE
Haetaan luvan kentät.

### DIFF
--- a/src/main/java/fi/minedu/oiva/backend/service/LupaService.java
+++ b/src/main/java/fi/minedu/oiva/backend/service/LupaService.java
@@ -51,7 +51,7 @@ public class LupaService implements RecordMapping<Lupa> {
     private AuthService authService;
 
     protected SelectOnConditionStep<Record> baseLupaSelect() {
-        return dsl.select().from(LUPA)
+        return dsl.select(LUPA.fields()).from(LUPA)
             .leftOuterJoin(LUPATILA).on(LUPATILA.ID.eq(LUPA.LUPATILA_ID));
     }
 


### PR DESCRIPTION
Vai onko tämä sittenkään bugi-fiksi. Joka tapauksessa ilman tuota getAll hakee myös kaikki kentät liitos-tauluista, jolloin ID kenttiä tulee useampi. Esim. lupa_id:lle tuleekin lupatila_id jsonissa. Pitää tarkentaa myöhemmin haettavia kenttiä, mikäli tarvitaan spesifisesti jotain muistakin tauluista kun lupa-taulusta.