### PR TITLE
Health check improvements, better error msgs when using princexml

### DIFF
--- a/oiva-core-model/src/main/java/fi/minedu/oiva/backend/model/util/ControllerUtil.java
+++ b/oiva-core-model/src/main/java/fi/minedu/oiva/backend/model/util/ControllerUtil.java
@@ -110,7 +110,7 @@ public final class ControllerUtil {
         return (ResponseEntity<T>) new ResponseEntity<>(msgMap, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    public static <T> ResponseEntity<T> getHealthCheckStatus(final HttpStatus status, final String description) {
+    public static <T> ResponseEntity<T> getHealthCheckStatus(final HttpStatus status, final Object description) {
         final Map<String, Object> message = new HashMap<>();
         message.put("status", status.value());
         message.put("description", description);

--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/CacheService.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/CacheService.java
@@ -66,14 +66,13 @@ public abstract class CacheService {
         });
     }
 
-    /**
-     * Throws exception if cannot connect to redis
-     */
-    protected void healthCheck() {
+    protected boolean healthCheck() {
         try {
             redisTemplate.getClientList();
+            return true;
         } catch(Exception e) {
-            throw new IllegalStateException("Redis failure");
+            logger.error("Cannot connect to redis", e);
+            return false;
         }
     }
 }

--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/HealthService.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/HealthService.java
@@ -1,39 +1,45 @@
 package fi.minedu.oiva.backend.core.service;
 
 import org.jooq.DSLContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 public class HealthService {
 
-    @Autowired
-    private DSLContext dsl;
+    private final DSLContext dsl;
+    private final CacheService cacheService;
+    private final PrinceXMLService princeXMLService;
+    private static final Logger logger = LoggerFactory.getLogger(HealthService.class);
 
     @Autowired
-    private CacheService cacheService;
-
-    @Autowired
-    private PrinceXMLService princeXMLService;
-
-    public void healthCheck() throws Exception {
-
-        // check database connection
-        databaseHealthCheck();
-
-        // check redis connection
-        cacheService.healthCheck();
-
-        // check princexml
-        princeXMLService.healthCheck();
+    HealthService(DSLContext dsl, CacheService cacheService, PrinceXMLService princeXMLService) {
+        this.dsl = dsl;
+        this.cacheService = cacheService;
+        this.princeXMLService = princeXMLService;
     }
 
-    private void databaseHealthCheck() throws Exception {
+    public Map<String, Boolean> healthCheck() throws Exception {
+        Map<String, Boolean> result = new HashMap<>();
+        result.put("database", databaseHealthCheck());
+        result.put("cache", cacheService.healthCheck());
+        result.put("princexml", princeXMLService.healthCheck());
+        return result;
+    }
+
+    private boolean databaseHealthCheck() {
         try {
             dsl.settings().withQueryTimeout(3);
             dsl.selectOne().fetch();
+            return true;
         } catch(Exception e) {
-            throw new IllegalStateException("Database Failure");
+            logger.error("Cannot connect to database", e);
+            return false;
         }
     }
 }

--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/PrinceXMLService.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/PrinceXMLService.java
@@ -15,7 +15,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import static fi.minedu.oiva.backend.model.entity.OivaTemplates.*;
+import static fi.minedu.oiva.backend.model.entity.OivaTemplates.AttachmentType;
+import static fi.minedu.oiva.backend.model.entity.OivaTemplates.RenderLanguage;
+import static fi.minedu.oiva.backend.model.entity.OivaTemplates.RenderOptions;
 
 @Service
 public class PrinceXMLService {
@@ -103,14 +105,7 @@ public class PrinceXMLService {
         return new Prince(princeExecPath, (msg1, msg2, msg3) -> logger.info("Prince data " + msg1 + " -- " + msg2 + " --- " + msg3));
     }
 
-    /**
-     *  Throws exception if princexml engine fails
-     */
-    protected void healthCheck() throws Exception {
-        try {
-            getPrinceEngine().convert(IOUtils.toInputStream("<html/>"), NullOutputStream.NULL_OUTPUT_STREAM);
-        } catch(Exception e) {
-            throw new IllegalStateException("PrinceXML failure");
-        }
+    protected boolean healthCheck()  {
+        return generatePDF("<html/>", NullOutputStream.NULL_OUTPUT_STREAM);
     }
 }

--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/PrinceXMLService.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/PrinceXMLService.java
@@ -1,6 +1,7 @@
 package fi.minedu.oiva.backend.core.service;
 
 import com.princexml.Prince;
+import com.princexml.PrinceEvents;
 import org.apache.pdfbox.util.PDFMergerUtility;
 import org.apache.tika.io.IOUtils;
 import org.apache.tika.io.NullOutputStream;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -38,7 +40,8 @@ public class PrinceXMLService {
     }
     public boolean toPDF(final String html, final OutputStream output, final RenderOptions options)  {
         final ByteArrayOutputStream basePDFStream = new ByteArrayOutputStream();
-        if(generatePDF(html, basePDFStream)) {
+        boolean succesfull = generatePDF(html, basePDFStream);
+        if(succesfull) {
             return appendAttachments(new ByteArrayInputStream(basePDFStream.toByteArray()), output, options);
         }
         return false;
@@ -93,16 +96,41 @@ public class PrinceXMLService {
             logger.error("prince.exec.path not defined");
             return false;
         }
-
-        try {
-            return getPrinceEngine().convert(IOUtils.toInputStream(html), output);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to generate PDF from html", e);
+        else if (!new File(princeExecPath).exists()) {
+            logger.error("PrinceXML binary executable not found in " + princeExecPath);
+            return false;
         }
+
+        String errorMsg = "Error using PrinceXML to generate PDF file. Make sure PrinceXML could be run manually: {} --version";
+        try {
+            boolean result = getPrinceEngine().convert(IOUtils.toInputStream(html), output);
+            if (result) {
+                return true;
+            }
+            else {
+                logger.error(errorMsg, princeExecPath);
+            }
+        } catch (IOException e) {
+            logger.error(errorMsg, princeExecPath, e);
+        }
+
+        return false;
+
     }
 
     protected Prince getPrinceEngine() {
-        return new Prince(princeExecPath, (msg1, msg2, msg3) -> logger.info("Prince data " + msg1 + " -- " + msg2 + " --- " + msg3));
+        PrinceEvents princeEvents = (msg1, msg2, msg3) -> {
+            if ("inf".equals(msg1)) {
+                logger.info("Prince data " + msg2 + " --- " + msg3);
+            } else if ("wrn".equals(msg1)) {
+                logger.warn("Prince data " + msg2 + " --- " + msg3);
+            } else if ("err".equals(msg1)) {
+                logger.error("Prince data " + msg2 + " --- " + msg3);
+            } else {
+                logger.error("Prince data Unknown level " + msg1 + " -- " + msg2 + " -- " + msg3);
+            }
+        };
+        return new Prince(princeExecPath, princeEvents);
     }
 
     protected boolean healthCheck()  {

--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/web/controller/BaseHealthController.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/web/controller/BaseHealthController.java
@@ -3,19 +3,18 @@ package fi.minedu.oiva.backend.core.web.controller;
 import fi.minedu.oiva.backend.core.security.annotations.OivaAccess_Public;
 import fi.minedu.oiva.backend.core.service.HealthService;
 import io.swagger.annotations.ApiOperation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import java.util.Map;
+
 import static fi.minedu.oiva.backend.model.util.ControllerUtil.getHealthCheckStatus;
+import static fi.minedu.oiva.backend.model.util.ControllerUtil.ok;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 public abstract class BaseHealthController {
-
-    private static final Logger logger = LoggerFactory.getLogger(BaseHealthController.class);
 
     public static final String path = "/health";
 
@@ -25,15 +24,13 @@ public abstract class BaseHealthController {
     @OivaAccess_Public
     @RequestMapping(method = GET)
     @ApiOperation(notes = "Testaa sovelluksen toimivuustilaa", value = "")
-    public HttpEntity<String> check() throws Exception {
-        try {
-            service.healthCheck();
-            logger.debug("Health-check: OK");
-            return getHealthCheckStatus(HttpStatus.OK, "OK");
-
-        } catch(Exception e) {
-            logger.error("Health-check: " + e.getMessage());
-            return getHealthCheckStatus(HttpStatus.INTERNAL_SERVER_ERROR, "Failed");
+    public HttpEntity<Map<?, ?>> check() throws Exception {
+        Map<String, Boolean> result = service.healthCheck();
+        if (result.values().stream().allMatch(Boolean.TRUE::equals)) {
+            return ok(result);
+        }
+        else {
+            return getHealthCheckStatus(HttpStatus.INTERNAL_SERVER_ERROR, result);
         }
     }
 }


### PR DESCRIPTION
Health check -rajapinta palauttaa samat http-koodit kuin aikaisemmin, mutta ajaa kaikki testit aikaisemman fail-fast-tyylin sijasta. Palauttaa kaikissa tapauksissa vastauksena tilat kaikille liittymille.

Lisätty virhetilanteiden lokitusta princexml-pdf-generoinnissa, jotta tilanteita voi selvittää lokien perusteella ilman lähdekoodin tutkimista ja debuggausta.