### PR TITLE
CSCKUJA-502 Lupa pdf is generated only for ammatillinenkoulutus.

### DIFF
--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/LupaService.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/LupaService.java
@@ -175,7 +175,7 @@ public class LupaService extends BaseService {
         final SelectOnConditionStep<Record> query = baseLupaSelect();
         baseLupaFilter().ifPresent(query::where);
         query.where(LUPA.JARJESTAJA_YTUNNUS.eq(ytunnus)
-                .and(LUPA.ALKUPVM.ge(DSL.currentDate()))
+                .and(LUPA.ALKUPVM.gt(DSL.currentDate()))
                 .and(koulutustyyppi == null ? LUPA.KOULUTUSTYYPPI.isNull() : LUPA.KOULUTUSTYYPPI.eq(koulutustyyppi)));
         return fetch(query, options);
     }
@@ -193,8 +193,8 @@ public class LupaService extends BaseService {
         final SelectConditionStep<Record> query = baseLupaSelect().where(LUPA.JARJESTAJA_YTUNNUS.eq(ytunnus)
                 .and(LUPA.ALKUPVM.le(DSL.currentDate()))
                 .and(LUPA.LOPPUPVM.isNull().or(LUPA.LOPPUPVM.ge(DSL.currentDate()))));
-        Optional.ofNullable(koulutustyyppi).ifPresent(tyyppi -> query.and(LUPA.KOULUTUSTYYPPI.eq(tyyppi)));
-        Optional.ofNullable(oppilaitostyyppi).ifPresent(tyyppi -> query.and(LUPA.OPPILAITOSTYYPPI.eq(tyyppi)));
+        query.and(koulutustyyppi == null ? LUPA.KOULUTUSTYYPPI.isNull() : LUPA.KOULUTUSTYYPPI.eq(koulutustyyppi));
+        query.and(oppilaitostyyppi == null ? LUPA.OPPILAITOSTYYPPI.isNull() : LUPA.OPPILAITOSTYYPPI.eq(oppilaitostyyppi));
         return get(query, useKoodistoVersions, withOptions);
     }
 

--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/MuutospyyntoService.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/MuutospyyntoService.java
@@ -342,8 +342,9 @@ public class MuutospyyntoService {
                     // Attach Päätöskirje from Muutospyyntö to new lupa
                     liiteService.createLupaLinkDbRecord(findPaatoskirjeLiite(muutospyynto.getLiitteet()).getId(),lupaRecord.getId());
 
-                    // Generate PDF for new lupa
+                    // Generate PDF for new lupa (Only for ammattillinenkoulutus)
                     lupaService.getById(lupaRecord.getId(), With.all)
+                            .filter(l -> l.getKoulutustyyppi() == null)
                             .ifPresent(l -> {
                                 try {
                                     fileStorageService.writeLupaPDF(l);

--- a/oiva-core/src/test/java/fi/minedu/oiva/backend/core/web/controller/BaseLupaControllerIT.java
+++ b/oiva-core/src/test/java/fi/minedu/oiva/backend/core/web/controller/BaseLupaControllerIT.java
@@ -109,11 +109,20 @@ public abstract class BaseLupaControllerIT extends BaseIT {
         setUpDb("sql/extra_lupa_data.sql");
         jdbcTemplate.update("update lupa set alkupvm = ?, koulutustyyppi = null, oppilaitostyyppi = null where diaarinumero = ?",
                 LocalDate.now().plusDays(3), "22/222/2020");
-        final ResponseEntity<String> response = makeRequest("/api/luvat/jarjestaja/1111111-1/tulevaisuus", HttpStatus.OK);
-        final DocumentContext doc = jsonPath.parse(response.getBody());
-        final List<String> diaariList = doc.read("$.[*].diaarinumero");
+        ResponseEntity<String> response = makeRequest("/api/luvat/jarjestaja/1111111-1/tulevaisuus", HttpStatus.OK);
+        DocumentContext doc = jsonPath.parse(response.getBody());
+        List<String> diaariList = doc.read("$.[*].diaarinumero");
         assertEquals(2, diaariList.size());
         assertTrue(diaariList.containsAll(Arrays.asList("22/222/2020", "23/223/2020")));
+
+        // Should not return lupa which is started in the same day.
+        jdbcTemplate.update("update lupa set alkupvm = ?, koulutustyyppi = null, oppilaitostyyppi = null where diaarinumero = ?",
+                LocalDate.now(), "22/222/2020");
+        response = makeRequest("/api/luvat/jarjestaja/1111111-1/tulevaisuus", HttpStatus.OK);
+        doc = jsonPath.parse(response.getBody());
+        diaariList = doc.read("$.[*].diaarinumero");
+        assertEquals(1, diaariList.size());
+        assertTrue(diaariList.contains("23/223/2020"));
     }
 
     @Test


### PR DESCRIPTION
- Fixed future lupa query when there is new lupa activated in current date.
- Fixed query for current active lupa when koulutustyyppi and oppilaitostyyppi is not given (ammatillinenkoulutus).