### PR TITLE
CSCOIVA-1683 Added support for longer diaarinumero values.

### DIFF
--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/Lupa.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/Lupa.java
@@ -42,7 +42,7 @@ import org.jooq.impl.TableImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Lupa extends TableImpl<LupaRecord> {
 
-    private static final long serialVersionUID = -221890737;
+    private static final long serialVersionUID = -374932391;
 
     /**
      * The reference instance of <code>lupa</code>
@@ -85,7 +85,7 @@ public class Lupa extends TableImpl<LupaRecord> {
     /**
      * The column <code>lupa.diaarinumero</code>.
      */
-    public final TableField<LupaRecord, String> DIAARINUMERO = createField("diaarinumero", org.jooq.impl.SQLDataType.VARCHAR.length(20).nullable(false).defaultValue(org.jooq.impl.DSL.field("concat(nextval('diaarinumero_seq'::regclass), '/999/', date_part('year'::text, (now())::date))", org.jooq.impl.SQLDataType.VARCHAR)), this, "");
+    public final TableField<LupaRecord, String> DIAARINUMERO = createField("diaarinumero", org.jooq.impl.SQLDataType.VARCHAR.length(255).nullable(false).defaultValue(org.jooq.impl.DSL.field("concat(nextval('diaarinumero_seq'::regclass), '/999/', date_part('year'::text, (now())::date))", org.jooq.impl.SQLDataType.VARCHAR)), this, "");
 
     /**
      * The column <code>lupa.jarjestaja_ytunnus</code>.

--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/Lupahistoria.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/Lupahistoria.java
@@ -38,7 +38,7 @@ import org.jooq.impl.TableImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Lupahistoria extends TableImpl<LupahistoriaRecord> {
 
-    private static final long serialVersionUID = 1148377819;
+    private static final long serialVersionUID = -644090075;
 
     /**
      * The reference instance of <code>lupahistoria</code>
@@ -61,7 +61,7 @@ public class Lupahistoria extends TableImpl<LupahistoriaRecord> {
     /**
      * The column <code>lupahistoria.diaarinumero</code>.
      */
-    public final TableField<LupahistoriaRecord, String> DIAARINUMERO = createField("diaarinumero", org.jooq.impl.SQLDataType.VARCHAR.length(20).nullable(false), this, "");
+    public final TableField<LupahistoriaRecord, String> DIAARINUMERO = createField("diaarinumero", org.jooq.impl.SQLDataType.VARCHAR.length(255).nullable(false), this, "");
 
     /**
      * The column <code>lupahistoria.ytunnus</code>.

--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/Muutospyynto.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/Muutospyynto.java
@@ -42,7 +42,7 @@ import org.jooq.impl.TableImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Muutospyynto extends TableImpl<MuutospyyntoRecord> {
 
-    private static final long serialVersionUID = -1762758434;
+    private static final long serialVersionUID = 1166214938;
 
     /**
      * The reference instance of <code>muutospyynto</code>
@@ -145,7 +145,7 @@ public class Muutospyynto extends TableImpl<MuutospyyntoRecord> {
     /**
      * The column <code>muutospyynto.diaarinumero</code>.
      */
-    public final TableField<MuutospyyntoRecord, String> DIAARINUMERO = createField("diaarinumero", org.jooq.impl.SQLDataType.VARCHAR.length(20), this, "");
+    public final TableField<MuutospyyntoRecord, String> DIAARINUMERO = createField("diaarinumero", org.jooq.impl.SQLDataType.VARCHAR.length(255), this, "");
 
     /**
      * The column <code>muutospyynto.jarjestaja_oid</code>.

--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/pojos/Lupa.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/pojos/Lupa.java
@@ -29,7 +29,7 @@ import javax.validation.constraints.Size;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Lupa implements Serializable {
 
-    private static final long serialVersionUID = 1783848954;
+    private static final long serialVersionUID = 800708240;
 
     private Long      id;
     private Long      edellinenLupaId;
@@ -168,7 +168,7 @@ public class Lupa implements Serializable {
         this.asiatyyppiId = asiatyyppiId;
     }
 
-    @Size(max = 20)
+    @Size(max = 255)
     public String getDiaarinumero() {
         return this.diaarinumero;
     }

--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/pojos/Lupahistoria.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/pojos/Lupahistoria.java
@@ -26,7 +26,7 @@ import javax.validation.constraints.Size;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Lupahistoria implements Serializable {
 
-    private static final long serialVersionUID = -296004993;
+    private static final long serialVersionUID = -1257978369;
 
     private Long   id;
     private String diaarinumero;
@@ -111,7 +111,7 @@ public class Lupahistoria implements Serializable {
     }
 
     @NotNull
-    @Size(max = 20)
+    @Size(max = 255)
     public String getDiaarinumero() {
         return this.diaarinumero;
     }

--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/pojos/Muutospyynto.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/pojos/Muutospyynto.java
@@ -29,7 +29,7 @@ import javax.validation.constraints.Size;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Muutospyynto implements Serializable {
 
-    private static final long serialVersionUID = -43834448;
+    private static final long serialVersionUID = 643516868;
 
     private Long      id;
     private Long      lupaId;
@@ -265,7 +265,7 @@ public class Muutospyynto implements Serializable {
         this.paatospvm = paatospvm;
     }
 
-    @Size(max = 20)
+    @Size(max = 255)
     public String getDiaarinumero() {
         return this.diaarinumero;
     }

--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/records/LupaRecord.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/records/LupaRecord.java
@@ -36,7 +36,7 @@ import org.jooq.impl.UpdatableRecordImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class LupaRecord extends UpdatableRecordImpl<LupaRecord> implements Record21<Long, Long, Long, Long, Long, String, String, String, Date, Date, Date, JsonNode, Boolean, String, Timestamp, String, Timestamp, UUID, String, String, String> {
 
-    private static final long serialVersionUID = -1059473752;
+    private static final long serialVersionUID = -163837526;
 
     /**
      * Setter for <code>lupa.id</code>.
@@ -121,7 +121,7 @@ public class LupaRecord extends UpdatableRecordImpl<LupaRecord> implements Recor
     /**
      * Getter for <code>lupa.diaarinumero</code>.
      */
-    @Size(max = 20)
+    @Size(max = 255)
     public String getDiaarinumero() {
         return (String) get(5);
     }

--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/records/LupahistoriaRecord.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/records/LupahistoriaRecord.java
@@ -33,7 +33,7 @@ import org.jooq.impl.UpdatableRecordImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class LupahistoriaRecord extends UpdatableRecordImpl<LupahistoriaRecord> implements Record16<Long, String, String, String, String, String, Date, Date, Date, String, UUID, String, Date, Long, String, String> {
 
-    private static final long serialVersionUID = 1605044730;
+    private static final long serialVersionUID = 1304964558;
 
     /**
      * Setter for <code>lupahistoria.id</code>.
@@ -60,7 +60,7 @@ public class LupahistoriaRecord extends UpdatableRecordImpl<LupahistoriaRecord> 
      * Getter for <code>lupahistoria.diaarinumero</code>.
      */
     @NotNull
-    @Size(max = 20)
+    @Size(max = 255)
     public String getDiaarinumero() {
         return (String) get(1);
     }

--- a/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/records/MuutospyyntoRecord.java
+++ b/oiva-core-model/src/main/generated/jooq/fi/minedu/oiva/backend/model/jooq/tables/records/MuutospyyntoRecord.java
@@ -36,7 +36,7 @@ import org.jooq.impl.UpdatableRecordImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class MuutospyyntoRecord extends UpdatableRecordImpl<MuutospyyntoRecord> implements Record20<Long, Long, Date, Date, Date, Long, String, String, String, Timestamp, String, Timestamp, UUID, JsonNode, String, String, Date, String, String, String> {
 
-    private static final long serialVersionUID = 299894228;
+    private static final long serialVersionUID = -1689445066;
 
     /**
      * Setter for <code>muutospyynto.id</code>.
@@ -294,7 +294,7 @@ public class MuutospyyntoRecord extends UpdatableRecordImpl<MuutospyyntoRecord> 
     /**
      * Getter for <code>muutospyynto.diaarinumero</code>.
      */
-    @Size(max = 20)
+    @Size(max = 255)
     public String getDiaarinumero() {
         return (String) get(17);
     }

--- a/oiva-core-model/src/main/resources/db/migration/V21__Change_diaarinumero_column_size.sql
+++ b/oiva-core-model/src/main/resources/db/migration/V21__Change_diaarinumero_column_size.sql
@@ -1,0 +1,4 @@
+-- Change diaarinumero column size in lupa, muutospyynto and lupahistoria tables.
+ALTER TABLE lupahistoria ALTER COLUMN diaarinumero TYPE VARCHAR(255);
+ALTER TABLE lupa ALTER COLUMN diaarinumero TYPE VARCHAR(255);
+ALTER TABLE muutospyynto ALTER COLUMN diaarinumero TYPE VARCHAR(255);

--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/MuutospyyntoService.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/MuutospyyntoService.java
@@ -326,7 +326,6 @@ public class MuutospyyntoService {
                             .orElseThrow(() -> new RuntimeException("Cannot find muutospyynto"));
                     lupaDTO.setLupatila(tila);
                     lupaDTO.setAsiatyyppi(asiatyyppi);
-                    lupaDTO.setDiaarinumero(lupaDTO.getAsianumero());
 
                     final LupaRecord lupaRecord = dsl.newRecord(LUPA, lupaDTO);
                     lupaRecord.setLupatilaId(tila.getId());
@@ -386,6 +385,7 @@ public class MuutospyyntoService {
             lupa.setAlkupvm(mp.getVoimassaalkupvm());
             lupa.setLoppupvm(mp.getVoimassaloppupvm());
             lupa.setEdellinenLupaId(oldLupa.map(Lupa::getId).orElse(null));
+            lupa.setDiaarinumero(StringUtils.isEmpty(lupa.getDiaarinumero()) ? lupa.getAsianumero() : lupa.getDiaarinumero());
 
             final Set<Long> removed = getMuutoksetRecursively(mp.getMuutokset())
                     .filter(MuutospyyntoService::isPoisto)

--- a/oiva-core/src/test/resources/json/muutospyynto.json
+++ b/oiva-core/src/test/resources/json/muutospyynto.json
@@ -1,6 +1,5 @@
 {
   "asianumero": "VN/123456/1234",
-  "diaarinumero": "20/531/2018",
   "jarjestajaOid": "1.1.111.111.11.11111111111",
   "jarjestajaYtunnus": "1111111-1",
   "luoja": "oiva-sanni",


### PR DESCRIPTION
- Some old PO-lupas needs to enter multiple comma separated diaarinumeros and that's why database varchar length is increased from 20 to 255.