### PR TITLE
CSCOIVA-1818 JarjestajaYtunnus nullable for lupa and muutospyynto.

### DIFF
--- a/oiva-core-model/src/main/resources/db/migration/V22__Muutospyynto_and_lupa_jarjestaja_ytunnus_nullable.sql
+++ b/oiva-core-model/src/main/resources/db/migration/V22__Muutospyynto_and_lupa_jarjestaja_ytunnus_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE muutospyynto ALTER COLUMN jarjestaja_ytunnus DROP NOT NULL;
+ALTER TABLE lupa ALTER COLUMN jarjestaja_ytunnus DROP NOT NULL;

--- a/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/MuutospyyntoService.java
+++ b/oiva-core/src/main/java/fi/minedu/oiva/backend/core/service/MuutospyyntoService.java
@@ -577,7 +577,7 @@ public class MuutospyyntoService {
 
     // Check that muutospyynto and lupa organizations match each other
     private boolean lupaAndMuutospyyntoOrganizationsMatch(final Muutospyynto toBeSaved) {
-        return lupaService.getByUuid(toBeSaved.getLupaUuid()).map(l -> l.getJarjestajaYtunnus().equals(toBeSaved.getJarjestajaYtunnus())).orElse(false);
+        return lupaService.getByUuid(toBeSaved.getLupaUuid()).map(l -> l.getJarjestajaOid().equals(toBeSaved.getJarjestajaOid())).orElse(false);
     }
 
     // Check that user is in same org than muutospyynto
@@ -886,7 +886,7 @@ public class MuutospyyntoService {
 
     private void withOrganization(final Muutospyynto muutospyynto) {
         Optional.ofNullable(muutospyynto)
-                .ifPresent(m -> organisaatioService.getWithLocation(m.getJarjestajaYtunnus())
+                .ifPresent(m -> organisaatioService.getWithLocation(m.getJarjestajaOid())
                         .ifPresent(m::setJarjestaja));
     }
 
@@ -1021,8 +1021,8 @@ public class MuutospyyntoService {
                     muutospyyntoRecord.getDiaarinumero());
             muutospyyntoRecord.setPaivityspvm(Timestamp.from(Instant.now()));
             Optional<Lupa> lupa = lupaService.getByUuid(muutospyynto.getLupaUuid());
-            if (lupa.map(m -> !m.getJarjestajaYtunnus().equals(muutospyynto.getJarjestajaYtunnus())).orElse(false)) {
-                throw new ForbiddenException("Muutospyynto jarjestajaYTunnus must be equal to lupa jarjestaja y-tunnus");
+            if (lupa.map(l -> !l.getJarjestajaOid().equals(muutospyynto.getJarjestajaOid())).orElse(false)) {
+                throw new ForbiddenException("Muutospyynto jarjestajaOid must be equal to lupa jarjestaja oid");
             }
             muutospyyntoRecord.setLupaId(lupa.map(Lupa::getId).orElse(null));
             muutospyyntoRecord.setPaatoskierrosId(paatoskierrosId);

--- a/oiva-core/src/main/scala/fi/minedu/oiva/backend/core/service/OpintopolkuService.scala
+++ b/oiva-core/src/main/scala/fi/minedu/oiva/backend/core/service/OpintopolkuService.scala
@@ -66,7 +66,7 @@ class OpintopolkuService extends CacheAware {
     def koodistoKooditPath(koodistoUri: String) = s"/$koodistoUri/koodi"
     def koodistoUrl(koodistoUri: String): String = koodistoServiceUrl + s"/$koodistoUri"
     def koodistoKoodiUrl(koodistoUri: String): String = koodistoServiceUrl + koodistoKooditPath(koodistoUri)
-    def koodiUri(koodistoUri: String, koodiArvo: String): String = s"${koodistoUri}_$koodiArvo"
+    def koodiUri(koodistoUri: String, koodiArvo: String = ""): String = s"${koodistoUri}_${koodiArvo.toLowerCase}"
 
     // Koodi urit
     def aluehallintovirastoKoodiUri(koodiArvo: String) = s"aluehallintovirasto_$koodiArvo"

--- a/oiva-core/src/test/java/fi/minedu/oiva/backend/core/service/LupamuutosServiceTest.java
+++ b/oiva-core/src/test/java/fi/minedu/oiva/backend/core/service/LupamuutosServiceTest.java
@@ -35,19 +35,19 @@ import static org.mockito.Mockito.when;
 
 public class LupamuutosServiceTest {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private LupamuutosService lupamuutosService;
-    private AuthService authService = mock(AuthService.class);
-    private LupaService lupaService = mock(LupaService.class);
+    private final AuthService authService = mock(AuthService.class);
+    private final LupaService lupaService = mock(LupaService.class);
 
-    private MuutospyyntoService service = mock(MuutospyyntoService.class);
+    private final MuutospyyntoService service = mock(MuutospyyntoService.class);
     private Lupa lupa;
 
     @Before
     public void setUp() {
         this.lupamuutosService = new LupamuutosService(service, authService);
         this.lupa = new Lupa();
-        this.lupa.setJarjestajaYtunnus("123");
+        this.lupa.setJarjestajaOid("123");
         when(lupaService.getByUuid(anyString())).thenReturn(Optional.of(lupa));
         Answer<Optional<Muutospyynto>> firstArgument = invocationOnMock -> {
             Muutospyynto mp = (Muutospyynto) invocationOnMock.getArguments()[0];
@@ -58,6 +58,7 @@ public class LupamuutosServiceTest {
         };
         when(service.save(any(Muutospyynto.class), anyMap())).thenAnswer(firstArgument);
         when(service.update(any(Muutospyynto.class), anyMap())).thenAnswer(firstArgument);
+        when(service.validAsianumero(anyString())).thenCallRealMethod();
     }
 
     @Test
@@ -165,7 +166,7 @@ public class LupamuutosServiceTest {
         Muutospyynto muutospyynto = new Muutospyynto();
         muutospyynto.setLiitteet(new LinkedList<>());
         muutospyynto.setMuutokset(new LinkedList<>());
-        muutospyynto.setJarjestajaYtunnus(lupa.getJarjestajaYtunnus());
+        muutospyynto.setJarjestajaOid(lupa.getJarjestajaOid());
         muutospyynto.setLupaUuid(UUID.randomUUID().toString());
         muutospyynto.setAsianumero("VN/1234/1234");
         return muutospyynto;
@@ -174,7 +175,7 @@ public class LupamuutosServiceTest {
     private void setUserOrgToMuutospyyntoOrg(String oid, Muutospyynto muutospyynto) {
         Organisaatio organisaatio = new Organisaatio();
         organisaatio.setOid(oid);
-        muutospyynto.setJarjestajaYtunnus(this.lupa.getJarjestajaYtunnus());
+        muutospyynto.setJarjestajaOid(this.lupa.getJarjestajaOid());
         this.lupa.setJarjestajaOid(oid);
         when(authService.getUserOrganisationOid()).thenReturn(oid);
     }

--- a/oiva-core/src/test/java/fi/minedu/oiva/backend/core/service/MuutospyyntoServiceTest.java
+++ b/oiva-core/src/test/java/fi/minedu/oiva/backend/core/service/MuutospyyntoServiceTest.java
@@ -64,20 +64,20 @@ import static org.mockito.Mockito.when;
 
 public class MuutospyyntoServiceTest {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
 
-    private DSLContext dsl = mock(DSLContext.class);
-    private AuthService authService = mock(AuthService.class);
-    private OrganisaatioService organisaatioService = mock(OrganisaatioService.class);
-    private LiiteService liiteService = mock(LiiteService.class);
-    private OpintopolkuService opintopolkuService = mock(OpintopolkuService.class);
-    private MaaraysService maaraysService = mock(MaaraysService.class);
-    private FileStorageService fileStorageService = mock(FileStorageService.class);
-    private AsiatilamuutosService asiatilamuutosService = mock(AsiatilamuutosService.class);
-    private LupaService lupaService = mock(LupaService.class);
-    private KoodistoService koodistoService = mock(KoodistoService.class);
-    private EsitysmalliService esitysmalliService = mock(EsitysmalliService.class);
+    private final DSLContext dsl = mock(DSLContext.class);
+    private final AuthService authService = mock(AuthService.class);
+    private final OrganisaatioService organisaatioService = mock(OrganisaatioService.class);
+    private final LiiteService liiteService = mock(LiiteService.class);
+    private final OpintopolkuService opintopolkuService = mock(OpintopolkuService.class);
+    private final MaaraysService maaraysService = mock(MaaraysService.class);
+    private final FileStorageService fileStorageService = mock(FileStorageService.class);
+    private final AsiatilamuutosService asiatilamuutosService = mock(AsiatilamuutosService.class);
+    private final LupaService lupaService = mock(LupaService.class);
+    private final KoodistoService koodistoService = mock(KoodistoService.class);
+    private final EsitysmalliService esitysmalliService = mock(EsitysmalliService.class);
 
     private MuutospyyntoService service;
     private Lupa lupa;
@@ -88,7 +88,7 @@ public class MuutospyyntoServiceTest {
                 opintopolkuService, maaraysService, fileStorageService, asiatilamuutosService, lupaService, koodistoService, esitysmalliService));
 
         this.lupa = new Lupa();
-        this.lupa.setJarjestajaYtunnus("123");
+        this.lupa.setJarjestajaOid("123");
         when(lupaService.getByUuid(anyString())).thenReturn(Optional.of(lupa));
     }
 
@@ -631,7 +631,7 @@ public class MuutospyyntoServiceTest {
     private void setUserOrgToMuutospyyntoOrg(String oid, Muutospyynto muutospyynto) {
         Organisaatio organisaatio = new Organisaatio();
         organisaatio.setOid(oid);
-        muutospyynto.setJarjestajaYtunnus(this.lupa.getJarjestajaYtunnus());
+        muutospyynto.setJarjestajaOid(this.lupa.getJarjestajaOid());
         this.lupa.setJarjestajaOid(oid);
         when(authService.getUserOrganisationOid()).thenReturn(oid);
     }

--- a/oiva-core/src/test/java/fi/minedu/oiva/backend/core/web/controller/BaseLupaControllerIT.java
+++ b/oiva-core/src/test/java/fi/minedu/oiva/backend/core/web/controller/BaseLupaControllerIT.java
@@ -27,8 +27,8 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class BaseLupaControllerIT extends BaseIT {
 
-    private static String PARAM_KOULUTUSTYYPPI = "koulutustyyppi";
-    private static String PARAM_OPPILAITOSTYYPPI = "oppilaitostyyppi";
+    private static final String PARAM_KOULUTUSTYYPPI = "koulutustyyppi";
+    private static final String PARAM_OPPILAITOSTYYPPI = "oppilaitostyyppi";
 
     @Autowired
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")

--- a/oiva-core/src/test/java/fi/minedu/oiva/backend/core/web/controller/BaseMuutospyyntoControllerIT.java
+++ b/oiva-core/src/test/java/fi/minedu/oiva/backend/core/web/controller/BaseMuutospyyntoControllerIT.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -97,6 +96,17 @@ public abstract class BaseMuutospyyntoControllerIT extends BaseIT {
         loginAs("testuser", lupaJarjestajaOid, OivaAccess.Context_Nimenkirjoittaja);
         final ResponseEntity<String> response = requestSave(prepareMultipartEntity(
                 readFileToString("json/muutospyynto.json")), "/api/muutospyynnot/tallenna");
+        assertEquals("Response code should match!", OK, response.getStatusCode());
+    }
+
+    @Test
+    public void saveWithoutYtunnus() throws IOException {
+        loginAs("testuser", lupaJarjestajaOid, OivaAccess.Context_Kayttaja);
+        final String json = readFileToString("json/muutospyynto.json");
+        final DocumentContext doc = jsonPath.parse(json);
+        doc.set("$.jarjestajaYtunnus", null);
+        final ResponseEntity<String> response = requestSave(prepareMultipartEntity(
+                doc.jsonString()), "/api/muutospyynnot/tallenna");
         assertEquals("Response code should match!", OK, response.getStatusCode());
     }
 
@@ -205,12 +215,15 @@ public abstract class BaseMuutospyyntoControllerIT extends BaseIT {
     public void testHappyPath() throws IOException {
         loginAs("testuser", lupaJarjestajaOid,
                 OivaAccess.Context_Kayttaja, OivaAccess.Context_Kayttaja);
-        // Create new muutospyynto
+        // Create new muutospyynto without ytunnus
+        final String json = readFileToString("json/muutospyynto.json");
+        DocumentContext doc = jsonPath.parse(json);
+        doc.set("$.jarjestajaYtunnus", null);
         ResponseEntity<String> createResponse = requestSave(prepareMultipartEntity(
-                readFileToString("json/muutospyynto.json"),
+                doc.jsonString(),
                 "file0", "file1", "file2", "file3", "file4", "file5"), "/api/muutospyynnot/tallenna");
         assertEquals("Response status should match", OK, createResponse.getStatusCode());
-        DocumentContext doc = jsonPath.parse(createResponse.getBody());
+        doc = jsonPath.parse(createResponse.getBody());
         final String uuid = doc.read("$.uuid", String.class);
         logout();
         // Change muutospyynto tila to "KASITTELYSSA"


### PR DESCRIPTION
- Changed organization checks to oid.
- Fixed unit tests
- Added lowercase to koodisto values. Koodistopalvelu api call does not support uppercase koodi values example kieli koodisto.